### PR TITLE
Support Kiali Iter8 monitoring dashboard

### DIFF
--- a/install/kubernetes/iter8-trend.yaml
+++ b/install/kubernetes/iter8-trend.yaml
@@ -28,7 +28,15 @@ rules:
   - experiments/status
   verbs:
   - get
-
+- apiGroups:
+  - '*'
+  resources:
+  - deployments
+  verbs:
+  - get
+  - list
+  - watch
+  
 ---
 # Source: iter8-trend/templates/clusterrolebinding.yaml
 apiVersion: rbac.authorization.k8s.io/v1

--- a/iter8-trend.py
+++ b/iter8-trend.py
@@ -392,7 +392,7 @@ class Iter8Watcher:
         thisLabel = mlabels.copy()
         thisLabel.append('diskmetric')
         gDisk = GaugeMetricFamily('iter8_trend_disk', '', labels=thisLabel)
-              
+
         thisLabel = mlabels.copy()
         thisLabel.append('networkmetric')
         gNetwork = GaugeMetricFamily('iter8_trend_network', '', labels=thisLabel)
@@ -407,7 +407,7 @@ class Iter8Watcher:
 
         for exp in self.experiments:
             for metric in self.experiments[exp].winner_data:
-  
+
                 self.doAddData( gAll, exp, metric, True)
 
                 if metric in ('networkreadbytes', 'networkwritebytes'):

--- a/iter8-trend.py
+++ b/iter8-trend.py
@@ -33,6 +33,7 @@ class Experiment:
 
         if 'metadata' in e and 'namespace' in e['metadata']:
             self.namespace = e['metadata']['namespace']
+            self.kubernetes_namespace = e['metadata']['namespace']
         if 'metadata' in e and 'name' in e['metadata']:
             self.name = e['metadata']['name']
 
@@ -55,7 +56,7 @@ class Experiment:
 
         # Used by Kiali only. Initialize to unknown since this data is populated
         # by Istio and put into Prometheus
-        self.winner_app = 'unknown'
+        self.winner_app = self.service_name
         self.winner_version = 'unknown'
 
         # Defaults winner to baseline
@@ -75,7 +76,7 @@ class Experiment:
             if 'assessment' in e['status']:
                 if 'winner' in e['status']['assessment']:
                     winner = e['status']['assessment']['winner']
-                    if winner['winning_version_found'] and self.phase == 'Completed':
+                    if winner['winning_version_found'] and self.phase == 'Completed' and winner['name'] != e['status']['assessment']['baseline']['name']:
                         # Only a Completed and Successful experiment is promoted
                         self.is_completed_and_successful = True
                         if 'name' in winner:
@@ -94,12 +95,16 @@ class Experiment:
                                 self.populate_winner_data(candidate['criterion_assessments'])
                                 break
 
+                    x = self.winner.split("-")
+                    self.winner_version = x[len(x)-1]
+
     # Populates self.winner_data
     def populate_winner_data(self, assessments):
         for assessment in assessments:
             name = assessment['id']
-            data = assessment['statistics']['value']
-            self.winner_data[name] = data
+            if 'value' in assessment['statistics']:
+                data = assessment['statistics']['value']
+                self.winner_data[name] = data
 
     # Prints an Experiment Custom Resource
     def __str__(self):
@@ -176,6 +181,7 @@ class Iter8Watcher:
                         exp = Experiment()
                         exp.winner_data = {}
                         exp.namespace = m['namespace']
+                        exp.kubernetes_namespace = m['namespace']
                         exp.name = m['name']
 
                         if 'baseline' in m and m['baseline'] != 'unknown':
@@ -200,13 +206,6 @@ class Iter8Watcher:
 
                         if 'app' in m and m['app'] != 'unknown':
                             exp.winner_app = m['app']
-                        else:
-                            exp.winner_app = 'unknown'
-
-                        if 'version' in m and m['version'] != 'unknown':
-                            exp.winner_version = m['version']
-                        else:
-                            exp.winner_version = 'unknown'
 
                         if 'service_name' in m and m['service_name'] != 'unknown':
                             exp.service_name = m['service_name']
@@ -343,21 +342,25 @@ class Iter8Watcher:
         while True:
             time.sleep(1)
 
-    def collect(self):
-        g = GaugeMetricFamily('iter8_trend', '', labels=['namespace',
-                                                         'name',
-                                                         'service_name',
-                                                         'baseline',
-                                                         'winner',
-                                                         'phase',
-                                                         'start_time',
-                                                         'time',
-                                                         'app',
-                                                         'version',
-                                                         'metric'])
-        for exp in self.experiments:
-            for metric in self.experiments[exp].winner_data:
-                g.add_metric([self.experiments[exp].namespace,
+    def doAddData(self, _g, exp, metric, withMetric):
+        if (withMetric == True) :
+            _g.add_metric([self.experiments[exp].namespace,
+                                self.experiments[exp].kubernetes_namespace,
+                                self.experiments[exp].name,
+                                self.experiments[exp].service_name,
+                                self.experiments[exp].baseline,
+                                self.experiments[exp].winner,
+                                self.experiments[exp].phase,
+                                self.experiments[exp].start_time,
+                                self.experiments[exp].end_time,
+                                self.experiments[exp].winner_app,
+                                self.experiments[exp].winner_version,
+                                metric],
+                                float(self.experiments[exp].winner_data[metric]))
+
+        else: 
+            _g.add_metric([self.experiments[exp].namespace,
+                              self.experiments[exp].kubernetes_namespace,
                               self.experiments[exp].name,
                               self.experiments[exp].service_name,
                               self.experiments[exp].baseline,
@@ -366,10 +369,63 @@ class Iter8Watcher:
                               self.experiments[exp].start_time,
                               self.experiments[exp].end_time,
                               self.experiments[exp].winner_app,
-                              self.experiments[exp].winner_version,
-                              metric],
+                              self.experiments[exp].winner_version],
                              float(self.experiments[exp].winner_data[metric]))
-        yield g
+
+    def collect(self):
+        mlabels=['namespace',
+                'kubernetes_namespace',
+                'name',
+                'service_name',
+                'baseline',
+                'winner',
+                'phase',
+                'start_time',
+                'time',
+                'app',
+                'version']
+        
+        thisLabel = mlabels.copy()
+        thisLabel.append('metric')
+        gAll = GaugeMetricFamily('iter8_trend', '', labels=thisLabel)
+
+        thisLabel = mlabels.copy()
+        thisLabel.append('diskmetric')  
+        gDisk = GaugeMetricFamily('iter8_trend_disk', '', labels=thisLabel)
+                                                         
+        thisLabel = mlabels.copy()
+        thisLabel.append('networkmetric') 
+        gNetwork = GaugeMetricFamily('iter8_trend_network', '', labels=thisLabel)
+
+        thisLabel = mlabels.copy()
+        thisLabel.append('iter8metric') 
+        gCustom = GaugeMetricFamily('iter8_trend_custom', '', labels=thisLabel)
+        
+        gCpu = GaugeMetricFamily('iter8_trend_cpu', '', labels=mlabels)
+
+        gMem = GaugeMetricFamily('iter8_trend_mem', '', labels=mlabels)
+
+        for exp in self.experiments:
+            for metric in self.experiments[exp].winner_data:
+                
+                self.doAddData( gAll, exp, metric, True)
+        
+                if metric == 'networkreadbytes' or metric == 'networkwritebytes' :
+                    self.doAddData( gNetwork, exp, metric, True)
+
+                elif metric == 'diskreadbytes' or metric == 'diskwritebytes':
+                    self.doAddData( gDisk, exp, metric, True)
+
+                elif metric == 'cpu':
+                    self.doAddData( gCpu, exp, metric, False)
+
+                elif metric == 'mem':
+                    self.doAddData( gMem, exp, metric, False)
+
+                else :
+                    self.doAddData( gCustom, exp, metric, True)
+
+        return[gAll, gDisk, gNetwork, gCpu, gMem, gCustom]
 
     # Monitors for new Experiments in the cluster and retrieves their
     # summary metrics data from Prometheus
@@ -395,7 +451,6 @@ class Iter8Watcher:
                         exp.winner_data['networkreadbytes'] = self.query_prometheus_network_read_bytes(exp.winner, exp)
                         exp.winner_data['networkwritebytes'] = self.query_prometheus_network_write_bytes(exp.winner, exp)
                         logger.info(exp)
-
             except client.rest.ApiException as e:
                 logger.error(f"Exception when calling CustomObjectApi->list_cluster_custom_object: {e}")
             except Exception as e:

--- a/iter8-trend.py
+++ b/iter8-trend.py
@@ -206,6 +206,13 @@ class Iter8Watcher:
 
                         if 'app' in m and m['app'] != 'unknown':
                             exp.winner_app = m['app']
+                        else:
+                            exp.winner_app = 'unknown'
+
+                        if 'version' in m and m['version'] != 'unknown':
+                            exp.winner_version = m['version']
+                        else:
+                            exp.winner_version = 'unknown'
 
                         if 'service_name' in m and m['service_name'] != 'unknown':
                             exp.service_name = m['service_name']

--- a/iter8-trend.py
+++ b/iter8-trend.py
@@ -343,7 +343,7 @@ class Iter8Watcher:
             time.sleep(1)
 
     def doAddData(self, _g, exp, metric, withMetric):
-        if (withMetric == True) :
+        if withMetric:
             _g.add_metric([self.experiments[exp].namespace,
                                 self.experiments[exp].kubernetes_namespace,
                                 self.experiments[exp].name,
@@ -358,7 +358,7 @@ class Iter8Watcher:
                                 metric],
                                 float(self.experiments[exp].winner_data[metric]))
 
-        else: 
+        else:
             _g.add_metric([self.experiments[exp].namespace,
                               self.experiments[exp].kubernetes_namespace,
                               self.experiments[exp].name,
@@ -384,36 +384,36 @@ class Iter8Watcher:
                 'time',
                 'app',
                 'version']
-        
+
         thisLabel = mlabels.copy()
         thisLabel.append('metric')
         gAll = GaugeMetricFamily('iter8_trend', '', labels=thisLabel)
 
         thisLabel = mlabels.copy()
-        thisLabel.append('diskmetric')  
+        thisLabel.append('diskmetric')
         gDisk = GaugeMetricFamily('iter8_trend_disk', '', labels=thisLabel)
-                                                         
+              
         thisLabel = mlabels.copy()
-        thisLabel.append('networkmetric') 
+        thisLabel.append('networkmetric')
         gNetwork = GaugeMetricFamily('iter8_trend_network', '', labels=thisLabel)
 
         thisLabel = mlabels.copy()
-        thisLabel.append('iter8metric') 
+        thisLabel.append('iter8metric')
         gCustom = GaugeMetricFamily('iter8_trend_custom', '', labels=thisLabel)
-        
+
         gCpu = GaugeMetricFamily('iter8_trend_cpu', '', labels=mlabels)
 
         gMem = GaugeMetricFamily('iter8_trend_mem', '', labels=mlabels)
 
         for exp in self.experiments:
             for metric in self.experiments[exp].winner_data:
-                
+  
                 self.doAddData( gAll, exp, metric, True)
-        
-                if metric == 'networkreadbytes' or metric == 'networkwritebytes' :
+
+                if metric in ('networkreadbytes', 'networkwritebytes'):
                     self.doAddData( gNetwork, exp, metric, True)
 
-                elif metric == 'diskreadbytes' or metric == 'diskwritebytes':
+                elif metric in ('diskreadbytes', 'diskwritebytes'):
                     self.doAddData( gDisk, exp, metric, True)
 
                 elif metric == 'cpu':

--- a/test/e2e-test.sh
+++ b/test/e2e-test.sh
@@ -18,8 +18,9 @@ fi
 # Exit on error
 set -e
 
-$DIR/../iter8/test/e2e/e2e-scenario-0a.sh
-$DIR/e2e-scenario-0a-verify.sh
+$DIR/../iter8/test/e2e/e2e-canary-scenario-1.sh
+$DIR/../iter8/test/e2e/e2e-canary-scenario-2.sh
+#$DIR/e2e-scenario-0a-verify.sh
 #$DIR/../iter8/test/e2e/e2e-scenario-0b.sh
 #$DIR/e2e-scenario-0b-verify.sh
 #$DIR/../iter8/test/e2e/e2e-scenario-0c.sh


### PR DESCRIPTION
1. add kubernetes_namespace because of kiali changes
2. add missing app and version
    app <- service_name
    version <- winner part of the version
3. additional checking for winning. if winner is baseline, it is considered failed.
4. check if there is value in assessment[statistics]
5. add additional query iter8_trend_cpu, iter8_trend_mem, iter8_trend_custom, iter8_trend_disk, iter8_trand_network